### PR TITLE
removed regexp version matching from mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Exlager.Mixfile do
 
   defp deps do
     [
-     {:lager, %r(.*), git: "https://github.com/basho/lager.git"},
+     {:lager, git: "https://github.com/basho/lager.git"},
     ]
   end
 end


### PR DESCRIPTION
When adding exlager as a dep in my mix project I got the following error:
*\* (Mix) Dependency specified in the wrong format: {:lager, %r".*", [git: "https://github.com/basho/lager.git"]}, expected { app :: atom, opts :: Keyword.t } | { app :: atom, requirement :: String.t
, opts :: Keyword.t }
Triggered by the depedency listing in the exlager project. Removed the regexp and it seems to work fine now.
