### PR TITLE
Change binary_to_list for String.to_char_list!

### DIFF
--- a/lib/lager.ex
+++ b/lib/lager.ex
@@ -54,7 +54,7 @@ defmodule Lager do
   defp log(level, format, args, caller) do
     {name, __arity} = caller.function || {:unknown, 0}
     module = caller.module || :unknown
-    if is_binary(format), do: format = binary_to_list(format)
+    if is_binary(format), do: format = String.to_char_list!(format)
     if should_log(level) do
        dispatch(level, module, name, caller.line, format, args)
     end


### PR DESCRIPTION
Elixir v0.10.2 deprecated binary_to_list:

https://github.com/elixir-lang/elixir/blob/v0.10.2/CHANGELOG.md#v0102-2013-09-03

```
binary_to_list/1 is deprecated. Please use String.to_char_list!/1
instead unless you are working with bytes, then you should use
:binary.bin_to_list/
```
