### PR TITLE
String.to_char_list! is now deprecated

### DIFF
--- a/lib/lager.ex
+++ b/lib/lager.ex
@@ -54,7 +54,7 @@ defmodule Lager do
   defp log(level, format, args, caller) do
     {name, __arity} = caller.function || {:unknown, 0}
     module = caller.module || :unknown
-    if is_binary(format), do: format = String.to_char_list!(format)
+    if is_binary(format), do: format = List.from_char_data!(format)
     if should_log(level) do
        dispatch(level, module, name, caller.line, format, args)
     end


### PR DESCRIPTION
This lets users of exlager to compile with elixir 0.13.2 without the "String.to_char_list!/1 is deprecated, please use List.from_char_data!/1 instead" warnings.
