### PR TITLE
String.to_char_list is back, List.from_char_data is deprecated...

### DIFF
--- a/lib/lager.ex
+++ b/lib/lager.ex
@@ -54,7 +54,7 @@ defmodule Lager do
   defp log(level, format, args, caller) do
     {name, _arity} = caller.function || {:unknown, 0}
     module = caller.module || :unknown
-    if is_binary(format), do: format = List.from_char_data!(format)
+    if is_binary(format), do: format = String.to_char_list(format)
     if should_log(level) do
       dispatch(level, module, name, caller.line, format, args)
     end


### PR DESCRIPTION
Elixir 0.13.3:

> [List] List.from_char_data/1 and List.from_char_data!/1 deprecated in favor of String.to_char_list/1
