### PR TITLE
Fix compilation warnings.

### DIFF
--- a/lib/lager.ex
+++ b/lib/lager.ex
@@ -1,16 +1,15 @@
 defmodule Lager do
-  defdelegate [
-     trace_console(filter),
-     trace_file(file, filter, level),
-     stop_trace(trace),
-     clear_all_traces(),
-     status(),
-     set_loglevel(handler, level),
-     set_loglevel(handler, indent, level),
-     get_loglevel(handler),
-     posix_error(error),
-     md, md(new_md_list)
-    ], to: :lager
+  defdelegate trace_console(filter), to: :lager
+  defdelegate trace_file(file, filter, level), to: :lager
+  defdelegate stop_trace(trace), to: :lager
+  defdelegate clear_all_traces(), to: :lager
+  defdelegate status(), to: :lager
+  defdelegate set_loglevel(handler, level), to: :lager
+  defdelegate set_loglevel(handler, indent, level), to: :lager
+  defdelegate get_loglevel(handler), to: :lager
+  defdelegate posix_error(error), to: :lager
+  defdelegate md, to: :lager
+  defdelegate md(new_md_list), to: :lager
 
   levels = [
     debug:      7,
@@ -55,7 +54,12 @@ defmodule Lager do
   defp log(level, format, args, caller) do
     {name, _arity} = caller.function || {:unknown, 0}
     module = caller.module || :unknown
-    if is_binary(format), do: format = String.to_char_list(format)
+    format =
+      if is_binary(format) do
+        String.to_char_list(format)
+      else
+        format
+      end
     if should_log(level) do
       dispatch(level, module, name, caller.line, format, args)
     end
@@ -85,8 +89,10 @@ defmodule Lager do
     if is_integer(level) do
       level = num_to_level(level)
       IO.puts "Using integers is deprecated, please use :#{level} instead"
+      level
+    else
+      level
     end
-    level
   end
 
   @doc """


### PR DESCRIPTION
After upgrading to Elixir 1.3.1, Lager compilation issued two warnings:

- Passing lists to defdelegate is deprecated.
- Assigning a variable inside case/if/receive control blocks is deprecated.

This commit performed a minor refactor to silence the warnings.