### PR TITLE
Fix Elixir 1.4 warnings about bare functions

### DIFF
--- a/lib/lager.ex
+++ b/lib/lager.ex
@@ -71,12 +71,12 @@ defmodule Lager do
         [module: unquote(module),
          function: unquote(name),
          line: unquote(line),
-         pid: self],
-        unquote(format), unquote(args), unquote(compile_truncation_size))
+         pid: self()],
+        unquote(format), unquote(args), unquote(compile_truncation_size()))
     end
   end
 
-  defp should_log(level), do: level_to_num(level) <= level_to_num(compile_log_level)
+  defp should_log(level), do: level_to_num(level) <= level_to_num(compile_log_level())
 
   @doc """
   This function is used to get compile time log level.

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Exlager.Mixfile do
       app: :exlager,
       version: "0.14.0",
       elixir: "> 0.14.0",
-      deps: deps
+      deps: deps()
     ]
   end
 


### PR DESCRIPTION
Elixir 1.4 gives warnings when arity 0 functions are used without parentheses, e.g.

    warning: variable "deps" does not exist and is being expanded to "deps()", please use
    parentheses to remove the ambiguity or change the variable name
      mix.exs:9

    warning: variable "compile_truncation_size" does not exist and is being expanded to
    "compile_truncation_size()", please use parentheses to remove the ambiguity or change the
    variable name
      lib/lager.ex:75

    warning: variable "compile_log_level" does not exist and is being expanded to
    "compile_log_level()", please use parentheses to remove the ambiguity or change the variable
     name
     lib/lager.ex:79

This PR adds parens to silence the warnings.