### PR TITLE
update lager to 3.2.4, add multiple sink support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ any negative impact on performance of a production system when you configure
 error level even if you have tons of debug messages.
 
 Information about location of a call (module, function, line, pid) is properly
-passed to lager for your convinience so you can easily find the source of a message.
+passed to lager for your convenience so you can easily find the source of a message.
 In this aspect using ExLager is equal to using parse transform shipped with
 basho lager.
 
@@ -72,8 +72,10 @@ Application.start :exlager
 Test.test
 ```
 
+Configuration
+-------------
 It is possible to configure truncation size and compile time log level.
-Beign a simple wrapper ExLager doesn't attempt to configure underlying Lager.
+Being a simple wrapper ExLager doesn't attempt to configure underlying Lager.
 You would need to configure it yourself [see](https://github.com/basho/lager) to ensure that:
 
   * lager_truncation_size >= compile_truncation_size
@@ -108,4 +110,13 @@ If you are mix user you could specify level and truncation_size in *config/confi
       truncation_size: 8096
 ```
 
+Multiple Sink Support
+---------------------
+As of Lager 3.x, you can configure multiple sinks to provide different behavior
+for different streams of logs.  To use a different sink, prepend the name to the
+logging calls above.  For example, to use the `magic_lager_event` sink, you can
+do the following:
 
+```
+Lager.info :magic, "magic event"
+```

--- a/lib/lager.ex
+++ b/lib/lager.ex
@@ -1,4 +1,6 @@
 defmodule Lager do
+  @default_sink :lager_event
+
   defdelegate trace_console(filter), to: :lager
   defdelegate trace_file(file, filter, level), to: :lager
   defdelegate stop_trace(trace), to: :lager
@@ -26,10 +28,18 @@ defmodule Lager do
   quoted = for {level, _num} <- levels do
     quote do
       defmacro unquote(level)(message) do
-        log(unquote(level), '~ts', [message], __CALLER__)
+        log(@default_sink, unquote(level), '~ts', [message], __CALLER__)
+      end
+      defmacro unquote(level)(sink, message) when is_atom(sink) do
+        sink_evt = String.to_atom(Atom.to_string(sink) <> "_lager_event")
+        log(sink_evt, unquote(level), '~ts', [message], __CALLER__)
       end
       defmacro unquote(level)(format, message) do
-        log(unquote(level), format, message, __CALLER__)
+        log(@default_sink, unquote(level), format, message, __CALLER__)
+      end
+      defmacro unquote(level)(sink, format, message) when is_atom(sink) do
+        sink_evt = String.to_atom(Atom.to_string(sink) <> "_lager_event")
+        log(sink_evt, unquote(level), format, message, __CALLER__)
       end
     end
   end
@@ -51,7 +61,7 @@ defmodule Lager do
   Module.eval_quoted __MODULE__, quoted, [], __ENV__
   defp num_to_level(_), do: nil
 
-  defp log(level, format, args, caller) do
+  defp log(sink, level, format, args, caller) do
     {name, _arity} = caller.function || {:unknown, 0}
     module = caller.module || :unknown
     format =
@@ -61,18 +71,19 @@ defmodule Lager do
         format
       end
     if should_log(level) do
-      dispatch(level, module, name, caller.line, format, args)
+      dispatch(sink, level, module, name, caller.line, format, args)
     end
   end
 
-  defp dispatch(level, module, name, line, format, args) do
+  defp dispatch(sink, level, module, name, line, format, args) do
     quote do
-      :lager.dispatch_log(unquote(level),
+      :lager.dispatch_log(unquote(sink), unquote(level),
         [module: unquote(module),
          function: unquote(name),
          line: unquote(line),
          pid: self()],
-        unquote(format), unquote(args), unquote(compile_truncation_size()))
+        unquote(format), unquote(args), unquote(compile_truncation_size()),
+        :safe)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Exlager.Mixfile do
 
   defp deps do
     [
-      {:lager, git: "https://github.com/basho/lager.git"},
+      {:lager, git: "https://github.com/basho/lager.git", tag: "3.2.4"},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"goldrush": {:git, "git://github.com/DeadZen/goldrush.git", "71e63212f12c25827e0c1b4198d37d5d018a7fec", [tag: "0.1.6"]},
-  "lager": {:git, "https://github.com/basho/lager.git", "4d8291edb72a25ac0efde907e2ecaa115108ff90", []}}
+%{"goldrush": {:git, "https://github.com/basho/goldrush.git", "8f1b715d36b650ec1e1f5612c00e28af6ab0de82", [tag: "0.1.9"]},
+  "lager": {:git, "https://github.com/basho/lager.git", "81eaef0ce98fdbf64ab95665e3bc2ec4b24c7dac", [tag: "3.2.4"]}}


### PR DESCRIPTION
I have an application that really needs to use multiple sinks.  The version of `lager` currently supported by `exlager` predates multiple sink support.

This pull request implements the following:

* updates Lager dependency
* add support for prepending a sink name to any of the currently supported `Lager` calls.
* documents it in the `README.md` file.

I did not provide any tests, since live testing of `lager` itself doesn't seem to be attempted in the current test suite and that would generally be required to see if an alternate sink actually works.  That said, I *did* test it in a live application and it works flawlessly.