### PR TITLE
Switch to Hex.pm-based package dependencies

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Exlager.Mixfile do
 
   defp deps do
     [
-      {:lager, git: "https://github.com/basho/lager.git", tag: "3.2.4"},
+      {:lager, "~> 3.2.4"},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"goldrush": {:git, "https://github.com/basho/goldrush.git", "8f1b715d36b650ec1e1f5612c00e28af6ab0de82", [tag: "0.1.9"]},
-  "lager": {:git, "https://github.com/basho/lager.git", "81eaef0ce98fdbf64ab95665e3bc2ec4b24c7dac", [tag: "3.2.4"]}}
+%{"goldrush": {:hex, :goldrush, "0.1.9", "f06e5d5f1277da5c413e84d5a2924174182fb108dabb39d5ec548b27424cd106", [:rebar3], []},
+  "lager": {:hex, :lager, "3.2.4", "a6deb74dae7927f46bd13255268308ef03eb206ec784a94eaf7c1c0f3b811615", [:rebar3], [{:goldrush, "0.1.9", [hex: :goldrush, optional: false]}]}}


### PR DESCRIPTION
We still point to the same versions of lager (and goldrush) that we were
using before.

This makes it easier for applications that use exlager to resolve their
own lager dependencies without resorting to overrides.