### PR TITLE
Add hex metadata

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,9 @@ defmodule Exlager.Mixfile do
       app: :exlager,
       version: "0.14.1",
       elixir: "> 0.14.0",
+      description: description(),
+      package: package(),
+      source_url: "https://github.com/khia/exlager",
       deps: deps()
     ]
   end
@@ -25,5 +28,17 @@ defmodule Exlager.Mixfile do
       {:lager, "~> 3.2.4"},
     ]
   end
-end
 
+  defp description() do
+    "This package implements a simple Elixir wrapper over basho/lager."
+  end
+
+  defp package() do
+    [
+      files: ["lib", "mix.exs", "README*", "readme*", "LICENSE*", "license*", "CHANGELOG.md", "package.head.exs"],
+      maintainers: ["ILYA Khlopotov"],
+      licenses: ["Apache 2.0"],
+      links: %{"GitHub" => "https://github.com/khia/exlager"}
+    ]
+  end
+end


### PR DESCRIPTION
This adds metadata for the Hex submission process: https://hex.pm/docs/publish